### PR TITLE
Increase portability to BSD

### DIFF
--- a/Loggable.C
+++ b/Loggable.C
@@ -617,7 +617,7 @@ Loggable::snapshot ( const char *name )
     {
 #ifndef __linux__
         // libgen basename requires a mutable string
-        char* bname = malloc(strlen(name) + sizeof(char));
+        char* bname = (char *)malloc(strlen(name) + sizeof(char));
         if ( bname == NULL )
         {
             DWARNING( "Could not malloc bname");

--- a/Loggable.C
+++ b/Loggable.C
@@ -33,6 +33,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifndef __linux__
+#include <libgen.h>
+#endif
+
 #include "file.h"
 
 // #include "const.h"
@@ -611,7 +615,20 @@ Loggable::snapshot ( const char *name )
     char *tmp  = NULL;
 
     {
+#ifndef __linux__
+        // libgen basename requires a mutable string
+        char* bname = malloc(strlen(name) + sizeof(char));
+        if ( bname == NULL )
+        {
+            DWARNING( "Could not malloc bname");
+            return false;
+        }
+        strcpy(bname, name);
+        const char *filename = basename(bname);
+        free(bname);
+#else
         const char *filename = basename(name);
+#endif
         char *dir = (char*)malloc( (strlen(name) - strlen(filename)) + 1 );
 
         if ( dir == NULL )

--- a/Mutex.H
+++ b/Mutex.H
@@ -23,41 +23,42 @@
 
 #include <pthread.h>
 
-const pthread_mutex_t _mutex_initializer = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
-
-class Mutex
-{
-
-    pthread_mutex_t _lock;
-
+class Mutex {
 public:
-
-    Mutex ( ) : _lock(_mutex_initializer)
-        { }
-
-    virtual ~Mutex ( )
+    Mutex()
         {
-            pthread_mutex_destroy( &_lock );
+            pthread_mutexattr_t attr;
+            pthread_mutexattr_init( &attr );
+            pthread_mutexattr_settype( &attr, PTHREAD_MUTEX_RECURSIVE );
+            pthread_mutex_init( &m_mutex, &attr );
+            pthread_mutexattr_destroy( &attr );
+        }
+
+    virtual ~Mutex()
+        {
+            pthread_mutex_destroy( &m_mutex );
         }
 
     void
     lock ( void )
         {
-            pthread_mutex_lock( &_lock );
+            pthread_mutex_lock( &m_mutex );
         }
 
     void
     unlock ( void )
         {
-            pthread_mutex_unlock( &_lock );
+            pthread_mutex_unlock( &m_mutex );
         }
 
     bool
     trylock ( void )
         {
-            return pthread_mutex_trylock( &_lock ) == 0;
+            return pthread_mutex_trylock( &m_mutex ) == 0;
         }
 
+private:
+    pthread_mutex_t m_mutex;
 };
 
 

--- a/debug.C
+++ b/debug.C
@@ -25,7 +25,13 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-extern char * program_invocation_short_name;
+#undef GET_PROGRAM_NAME
+#ifdef __GLIBC__
+#   define GET_PROGRAM_NAME() program_invocation_short_name
+#else /* *BSD and OS X */
+#   include <stdlib.h>
+#   define GET_PROGRAM_NAME() getprogname()
+#endif
 
 void
 warnf ( warning_t level,
@@ -40,7 +46,7 @@ warnf ( warning_t level,
 		"assertion", "\033[1;31m"
 	};
 
-        module = program_invocation_short_name;
+        module = GET_PROGRAM_NAME();
 
 	if ( module )
 		fprintf( stderr, "[\033[1;30m%s\033[0m] ", module );

--- a/file.C
+++ b/file.C
@@ -26,7 +26,12 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#ifdef __linux__
 #include <sys/vfs.h>
+#else
+#include <sys/mount.h>
+#include <sys/param.h>
+#endif
 
 unsigned long
 modification_time ( const char *file )


### PR DESCRIPTION
Hi, these are some cleaned up changes as discussed in https://github.com/Stazed/non-mixer-xt/issues/58

This seems to be all that is needed for nonlib at least. Mixer and Timeline are not so happy with their calls to std::list::sort(). In the spirit of asking ChatGPT for fun it reckons that it's due to Plugin Info not being const in the comparison. I know nothing about C++ STL but I'll try that next.

> This isn’t actually a problem with FreeBSD’s C++ standard library itself — it’s exposing a bug (or at least a non-portable assumption) in your code.
> 
> ### What’s going wrong
> 
> You’re calling:
> 
> ```cpp
> g_plugin_cache.sort();
> ```
> 
> where:
> 
> ```cpp
> std::list<Plugin_Info> g_plugin_cache;
> ```
> 
> When you call `list::sort()` with no arguments, the standard library uses:
> 
> ```cpp
> operator< (const T&, const T&)
> ```
> 
> internally.
> 
> So it tries to do:
> 
> ```cpp
> lhs < rhs
> ```
> 
> for two `const Plugin_Info` objects.
> 
> But your `operator<` is defined as:
> 
> ```cpp
> bool operator<(const Plugin_Info& rhs)
> ```
> 
> (from `Plugin_Info.H:68`)
> 
> Notice the problem:
> 
> 👉 It is **not marked `const`**.
> 
> That means it can’t be called on a `const Plugin_Info`, and during sorting the elements are treated as `const`.
> 
> So libc++ (used on FreeBSD) correctly rejects this.
> 
> Other platforms / libstdc++ are sometimes more permissive, which is why it may have “worked” elsewhere.
> 
> ---
> 
> ### The fix
> 
> Change your comparison operator to be `const`:
> 
> In `Plugin_Info.H`, change:
> 
> ```cpp
> bool operator< ( const Plugin_Info &rhs )
> ```
> 
> to:
> 
> ```cpp
> bool operator< ( const Plugin_Info &rhs ) const
> ```
> 
> So it becomes:
> 
> ```cpp
> bool operator<(const Plugin_Info& rhs) const
> {
>     // your comparison logic
> }
> ```
> 
> This tells the compiler:
> 
> > “Comparing two Plugin_Info objects does not modify either of them.”
> 
> Which is exactly what `std::list::sort()` requires.
> 
> ---
> 
> ### Why FreeBSD shows this
> 
> FreeBSD uses **Clang + libc++** by default.
> 
> libc++ is very strict about const-correctness and standard compliance.
> 
> Linux + GCC + libstdc++ often lets this slide, so the bug stays hidden.
> 
> So FreeBSD is doing you a favour here 🙂
> 
> ---
> 
> ### Alternative (if you can’t change the class)
> 
> If for some reason you can’t modify `Plugin_Info`, you could pass your own comparator:
> 
> ```cpp
> g_plugin_cache.sort([](const Plugin_Info& a,
>                        const Plugin_Info& b) {
>     return a < b;
> });
> ```
> 
> But this will still fail unless `operator<` is const, so it’s not really a solution in your case.
> 
> ---
> 
> ### Summary
> 
> Your error happens because:
> 
> * `std::list::sort()` needs `const` comparison
> * Your `operator<` is not `const`
> * libc++ enforces this strictly
> 
> ✅ Fix:
> 
> ```cpp
> bool operator<(const Plugin_Info& rhs) const;
> ```
> 
> After this change, your build on FreeBSD should succeed.
> 
> ---
> 
> If you’d like, you can paste your `Plugin_Info` class here and I can quickly check it for other portability issues before they bite you later.
> 